### PR TITLE
#9 Indexing ContentComplexReference

### DIFF
--- a/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
+++ b/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
@@ -9,6 +9,7 @@ namespace Forte.EpiServer.AzureSearch.Model
         public string[] ContentBody { get; set; }
 		
         public int ContentId { get; set; }
+        public string ContentComplexReference { get; set; }
         public string ContentImageUrl { get; set; }
         public int ContentImageReferenceId { get; set; }
 		

--- a/Forte.EpiServer.AzureSearch/Model/DefaultDocumentBuilder.cs
+++ b/Forte.EpiServer.AzureSearch/Model/DefaultDocumentBuilder.cs
@@ -45,6 +45,7 @@ namespace Forte.EpiServer.AzureSearch.Model
             {
                 Id = content.GetDocumentUniqueId(),
                 ContentId = content.ContentLink.ID,
+                ContentComplexReference = content.ContentLink.ToString(),
                 ContentName = content.Name,
             };
 

--- a/Forte.EpiServer.AzureSearch/SearchProvider/ContentSearchProviderBase.cs
+++ b/Forte.EpiServer.AzureSearch/SearchProvider/ContentSearchProviderBase.cs
@@ -38,14 +38,14 @@ namespace Forte.EpiServer.AzureSearch.SearchProvider
                 previewText = result.Highlights.First().Value.First();
             }
 
-            var editModeUrl = PageEditing.GetEditUrlForLanguage(new ContentReference(result.Document.ContentId), result.Document.ContentLanguage); 
+            var editModeUrl = PageEditing.GetEditUrlForLanguage(new ContentReference(result.Document.ContentComplexReference), result.Document.ContentLanguage); 
             
             return new SearchResult(editModeUrl, result.Document.ContentName, previewText)
             {
                 Metadata =
                 {
                     new KeyValuePair<string, string>("languageBranch", result.Document.ContentLanguage),
-                    new KeyValuePair<string, string>("id", result.Document.ContentId.ToString())
+                    new KeyValuePair<string, string>("id", result.Document.ContentComplexReference)
                 }
             };
         }


### PR DESCRIPTION
This is implementation of issue reported here: #9 

This is adding new field in the index. DefaultDocumentBuilder saves ContentReference.ToString() value which includes additional information about content, including ContentProviderId