### PR TITLE
Adding null check in case OldUrl is not set 

### DIFF
--- a/Forte.EpiServer.AzureSearch/Events/PageDocumentsProvider.cs
+++ b/Forte.EpiServer.AzureSearch/Events/PageDocumentsProvider.cs
@@ -28,7 +28,7 @@ namespace Forte.EpiServer.AzureSearch.Events
 
         public IReadOnlyCollection<T> GetDocuments(IContent page, ContentEventArgs contentEventArgs)
         {
-            var oldUrl = contentEventArgs.Items[OldUrlKey].ToString();
+            var oldUrl = contentEventArgs.Items[OldUrlKey]?.ToString();
             var newUrl = _urlResolver.GetUrl(contentEventArgs.ContentLink);
             
             var isUrlChanged = oldUrl != newUrl;


### PR DESCRIPTION
ie in case of pages without template - such pages don't have url