### PR TITLE
Fixing the way content is extracted from XhtmlString.

### DIFF
--- a/Forte.EpiServer.AzureSearch.Tests/ContentExtractor/XhtmlStringExtractorTests.cs
+++ b/Forte.EpiServer.AzureSearch.Tests/ContentExtractor/XhtmlStringExtractorTests.cs
@@ -26,10 +26,9 @@ namespace Forte.EpiServer.AzureSearch.Tests.ContentExtractor
         [TestCaseSource(nameof(PlainTextContentSource))]
         public void GetPlainTextContentShouldReturnValidText(XhtmlString testString, string expectedString)
         {
-            var strippedText = _xhtmlStringExtractor.GetPlainTextContent(testString, _contentExtractorController).Trim();
+            var strippedText = _xhtmlStringExtractor.GetPlainTextContent(testString, _contentExtractorController);
             
             Assert.That(strippedText, Is.EqualTo(expectedString));
-            
         }
         
         private static IEnumerable<TestCaseData> PlainTextContentSource()

--- a/Forte.EpiServer.AzureSearch.Tests/ContentExtractor/XhtmlStringExtractorTests.cs
+++ b/Forte.EpiServer.AzureSearch.Tests/ContentExtractor/XhtmlStringExtractorTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using EPiServer;
+using EPiServer.Core;
+using EPiServer.Core.Html.StringParsing;
+using Forte.EpiServer.AzureSearch.ContentExtractor;
+using Moq;
+using NUnit.Framework;
+
+namespace Forte.EpiServer.AzureSearch.Tests.ContentExtractor
+{
+    [TestFixture]
+    public class XhtmlStringExtractorTests
+    {
+        private XhtmlStringExtractor _xhtmlStringExtractor;
+        private IContentExtractorController _contentExtractorController;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            var contentLoader = new Mock<IContentLoader>();
+            _xhtmlStringExtractor = new XhtmlStringExtractor(contentLoader.Object);
+            _contentExtractorController = new Mock<IContentExtractorController>().Object;
+        }
+
+        [Test]
+        [TestCaseSource(nameof(PlainTextContentSource))]
+        public void GetPlainTextContentShouldReturnValidText(XhtmlString testString, string expectedString)
+        {
+            var strippedText = _xhtmlStringExtractor.GetPlainTextContent(testString, _contentExtractorController).Trim();
+            
+            Assert.That(strippedText, Is.EqualTo(expectedString));
+            
+        }
+        
+        private static IEnumerable<TestCaseData> PlainTextContentSource()
+        {
+            var imgWithTextAfter = new XhtmlString();
+            imgWithTextAfter.Fragments.Add(new StaticFragment("<img src=\""));
+            imgWithTextAfter.Fragments.Add(new UrlFragment("~/link/1b108a4b8f9a4b47802f0112f5b07d11.aspx"));
+            imgWithTextAfter.Fragments.Add(new StaticFragment("\" alt=\"alt\"/><p>text</p>"));
+            
+            yield return new TestCaseData(imgWithTextAfter, "text").SetName("Img with plain text after");
+            
+            var imgWithTextBeforeAndAfter = new XhtmlString();
+            imgWithTextBeforeAndAfter.Fragments.Add(new StaticFragment("<p>1</p>"));
+            imgWithTextBeforeAndAfter.Fragments.Add(new StaticFragment("<img src=\""));
+            imgWithTextBeforeAndAfter.Fragments.Add(new UrlFragment("~/link/1b108a4b8f9a4b47802f0112f5b07d11.aspx"));
+            imgWithTextBeforeAndAfter.Fragments.Add(new StaticFragment("\" alt=\"alt\"/><p>2</p>"));
+            
+            yield return new TestCaseData(imgWithTextBeforeAndAfter, "1 2").SetName("Img with plain text in before and after");
+        }
+    }
+}

--- a/Forte.EpiServer.AzureSearch.Tests/Forte.EpiServer.AzureSearch.Tests.csproj
+++ b/Forte.EpiServer.AzureSearch.Tests/Forte.EpiServer.AzureSearch.Tests.csproj
@@ -33,15 +33,122 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\packages\Castle.Windsor.4.1.0\lib\net45\Castle.Windsor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.CMS.Core.11.13.0\lib\net461\EPiServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.ApplicationModules, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.Framework.11.13.0\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.Data, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.Framework.11.13.0\lib\net461\EPiServer.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.Data.Cache, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.Framework.11.13.0\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.Enterprise, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.CMS.Core.11.13.0\lib\net461\EPiServer.Enterprise.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.Events, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.Framework.11.13.0\lib\net461\EPiServer.Events.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.Framework, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.Framework.11.13.0\lib\net461\EPiServer.Framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.Licensing, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.Framework.11.13.0\lib\net461\EPiServer.Licensing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EPiServer.LinkAnalyzer, Version=11.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\packages\EPiServer.CMS.Core.11.13.0\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.14.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920">
+      <HintPath>..\packages\Moq.4.14.7\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.ComponentModel.Annotations.4.4.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.Data.SqlClient, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Data.SqlClient.4.4.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Security.Cryptography.Xml.4.4.2\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Permissions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Security.Permissions.4.4.0\lib\net461\System.Security.Permissions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.AccessControl, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Threading.AccessControl.4.4.0\lib\net461\System.Threading.AccessControl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
       <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContentExtractor\XhtmlStringExtractorTests.cs" />
     <Compile Include="Query\AzureSearchQueryBuilderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -50,6 +157,9 @@
       <Project>{819cfefe-8eef-4d27-afaa-c8fda760401f}</Project>
       <Name>Forte.EpiServer.AzureSearch</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Forte.EpiServer.AzureSearch.Tests/packages.config
+++ b/Forte.EpiServer.AzureSearch.Tests/packages.config
@@ -1,4 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
+  <package id="Castle.Windsor" version="4.1.0" targetFramework="net471" />
+  <package id="EPiServer.CMS.Core" version="11.13.0" targetFramework="net471" />
+  <package id="EPiServer.Framework" version="11.13.0" targetFramework="net471" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net471" />
+  <package id="Moq" version="4.14.7" targetFramework="net471" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
+  <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net471" />
+  <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net471" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net471" />
+  <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Xml" version="4.4.2" targetFramework="net471" />
+  <package id="System.Security.Permissions" version="4.4.0" targetFramework="net471" />
+  <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net471" />
+  <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
 </packages>

--- a/Forte.EpiServer.AzureSearch/ContentExtractor/XhtmlStringExtractor.cs
+++ b/Forte.EpiServer.AzureSearch/ContentExtractor/XhtmlStringExtractor.cs
@@ -41,7 +41,7 @@ namespace Forte.EpiServer.AzureSearch.ContentExtractor
                     {
                         if (staticFragments.Any())
                         {
-                            texts.Add(RemoveScripts(string.Join("", staticFragments)));
+                            texts.Add(RemoveScripts(staticFragments));
                             staticFragments.Clear();
                         }
                         
@@ -59,7 +59,7 @@ namespace Forte.EpiServer.AzureSearch.ContentExtractor
             
             if (staticFragments.Any())
             {
-                texts.Add(RemoveScripts(string.Join("", staticFragments)));
+                texts.Add(RemoveScripts(staticFragments));
             }
 
             var joinedText = string.Join(ContentExtractorController.BlockExtractedTextFragmentsSeparator,
@@ -70,9 +70,14 @@ namespace Forte.EpiServer.AzureSearch.ContentExtractor
         private static string StripHtml(string html)
         {
             const string moreTextMarker = "...";
-            return TextIndexer.StripHtml(html, int.MaxValue, int.MaxValue, moreTextMarker);
+            return TextIndexer.StripHtml(html, int.MaxValue, int.MaxValue, moreTextMarker).Trim();
         }
 
+        private static string RemoveScripts(IEnumerable<string> strings)
+        {
+            return RemoveScripts(string.Join("", strings));
+        }
+        
         private static string RemoveScripts(string htmlString)
         {
             var parser = new AngleSharp.Html.Parser.HtmlParser();

--- a/Forte.EpiServer.AzureSearch/ContentExtractor/XhtmlStringExtractor.cs
+++ b/Forte.EpiServer.AzureSearch/ContentExtractor/XhtmlStringExtractor.cs
@@ -25,6 +25,7 @@ namespace Forte.EpiServer.AzureSearch.ContentExtractor
                 return string.Empty;
             }
             var texts = new List<string>();
+            var staticFragments = new List<string>();
 
             var xhtmlFragments = xhtmlString
                 .Fragments
@@ -38,6 +39,12 @@ namespace Forte.EpiServer.AzureSearch.ContentExtractor
                         continue;
                     case ContentFragment contentFragment:
                     {
+                        if (staticFragments.Any())
+                        {
+                            texts.Add(RemoveScripts(string.Join("", staticFragments)));
+                            staticFragments.Clear();
+                        }
+                        
                         var content = _contentLoader.Get<IContent>(contentFragment.ContentLink);
                         
                         texts.Add(extractor.ExtractBlock(content));
@@ -45,11 +52,14 @@ namespace Forte.EpiServer.AzureSearch.ContentExtractor
                     }
                     case StaticFragment staticFragment:
                         var html = staticFragment.InternalFormat;
-                        var htmlWithoutScripts = RemoveScripts(html);
-
-                        texts.Add(htmlWithoutScripts);
+                        staticFragments.Add(html);
                         break;
                 }
+            }
+            
+            if (staticFragments.Any())
+            {
+                texts.Add(RemoveScripts(string.Join("", staticFragments)));
             }
 
             var joinedText = string.Join(ContentExtractorController.BlockExtractedTextFragmentsSeparator,

--- a/Forte.EpiServer.AzureSearch/Forte.EpiServer.AzureSearch.csproj
+++ b/Forte.EpiServer.AzureSearch/Forte.EpiServer.AzureSearch.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.13.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.0.13.0\lib\net46\AngleSharp.dll</HintPath>
+    <Reference Include="AngleSharp, Version=0.14.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea">
+      <HintPath>..\packages\AngleSharp.0.14.0\lib\net461\AngleSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>

--- a/Forte.EpiServer.AzureSearch/packages.config
+++ b/Forte.EpiServer.AzureSearch/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.13.0" targetFramework="net471" />
+  <package id="AngleSharp" version="0.14.0" targetFramework="net471" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net471" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net471" />
   <package id="EPiServer.CMS.AspNet" version="11.13.0" targetFramework="net471" />


### PR DESCRIPTION
Current implementation of GetPlainTextContent is buggy:

This is how EpiServer splits XhtmlString into fragments:

![image](https://user-images.githubusercontent.com/1555694/98552576-e9587e00-229e-11eb-83e5-bba3956620ec.png)

This results in situation in which loop iterates over fragments and treats them as separate items. In the end a collection of strings produced by this loop is:
![image](https://user-images.githubusercontent.com/1555694/98553090-85828500-229f-11eb-919e-2e7ed444ec88.png)

This PR joins all non ContentFragment fragments into separate pieces and work on these combined instead of treating each as separate one (being separate fragment does not have valid html inside)