### PR TITLE
Fix for handling non default language version

### DIFF
--- a/Forte.EpiServer.AzureSearch/Events/PageDocumentsProvider.cs
+++ b/Forte.EpiServer.AzureSearch/Events/PageDocumentsProvider.cs
@@ -118,9 +118,9 @@ namespace Forte.EpiServer.AzureSearch.Events
 
         private T GetPageLanguageBranchContentDocument(ContentReference contentLink, CultureInfo language)
         {
-            var content = _contentLoader.Get<IContent>(new ContentReference(contentLink.ID), language);
+            var content = _contentLoader.Get<IContent>(contentLink.ToReferenceWithoutVersion(), language);
             
-            if (content.ShouldIndexPage() == false)
+            if (content?.ShouldIndexPage() != true)
             {
                 return null;
             }


### PR DESCRIPTION
Fix for two issues:
- contentLink ID is not enough to create ContentReference in case of external contentProviders
- there are setups in which IContentLoader.Get might return null (with language version set explicitly)