### PR TITLE
Preserve old index when job fails

### DIFF
--- a/Forte.EpiServer.AzureSearch.Tests/Query/AzureSearchQueryBuilderTests.cs
+++ b/Forte.EpiServer.AzureSearch.Tests/Query/AzureSearchQueryBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Forte.EpiServer.AzureSearch.Query;
 using NUnit.Framework;
@@ -50,6 +51,28 @@ namespace Forte.EpiServer.AzureSearch.Tests.Query
                         })),
                     "(Field1 eq 1 and (Field2 eq 2 or Field3 eq 3))")
                 .SetName("Grouped expressions setup in single Filter call");
+
+            yield return new TestCaseData(
+                    new AzureSearchQueryBuilder().Filter(new NotFilter(AzureSearchQueryFilter.Equals("Field1", 1))),
+                    "(not Field1 eq 1)")
+                .SetName("Negated Filter");
+
+            yield return new TestCaseData(
+                    new AzureSearchQueryBuilder().Filter(new AzureSearchFilterSearchIn("Field1", new[] {"1", "120", "22"})),
+                    "(search.in(Field1, '1 120 22', ' '))")
+                .SetName("Filter with search.in function");
+
+            yield return new TestCaseData(
+                    new AzureSearchQueryBuilder().Filter(new AzureSearchFilterSearchIn("Field1", Array.Empty<string>())),
+                    "(search.in(Field1, '', ' '))")
+                .SetName("Filter with search.in function but with empty enumerable");
+
+            yield return new TestCaseData(
+                    new AzureSearchQueryBuilder()
+                        .Filter(AzureSearchQueryFilter.GreaterThan("Field1", 500))
+                        .Filter(new NotFilter(new AzureSearchFilterSearchIn("Field2", new[] {"1", "120", "22"}, ", "))),
+                    "(Field1 gt 500) and (not search.in(Field2, '1, 120, 22', ', '))")
+                .SetName("Filter with negated search.in function and simple greater than query");
         }
 
         [Test]

--- a/Forte.EpiServer.AzureSearch/Exceptions/ScheduledJobFailedException.cs
+++ b/Forte.EpiServer.AzureSearch/Exceptions/ScheduledJobFailedException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Forte.EpiServer.AzureSearch.Exceptions
+{
+    public class ScheduledJobFailedException : Exception
+    {
+        public ScheduledJobFailedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/Forte.EpiServer.AzureSearch/Forte.EpiServer.AzureSearch.csproj
+++ b/Forte.EpiServer.AzureSearch/Forte.EpiServer.AzureSearch.csproj
@@ -266,6 +266,7 @@
     <Compile Include="Events\BlockDocumentsProvider.cs" />
     <Compile Include="Events\PageDocumentsProvider.cs" />
     <Compile Include="Events\SearchEventHandler.cs" />
+    <Compile Include="Exceptions\ScheduledJobFailedException.cs" />
     <Compile Include="Extensions\AzureSearchServiceExtensions.cs" />
     <Compile Include="Extensions\ContentExtensions.cs" />
     <Compile Include="Extensions\ContentLoaderExtensions.cs" />
@@ -291,6 +292,7 @@
     <Compile Include="Plugin\IndexDefinitionHandler.cs" />
     <Compile Include="Plugin\IndexStatistics.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\AzureSearchFilterSearchIn.cs" />
     <Compile Include="Query\AzureSearchQuery.cs" />
     <Compile Include="Query\AzureSearchQueryBuilder.cs" />
     <Compile Include="Query\AzureSearchQueryFilter.cs" />
@@ -298,6 +300,7 @@
     <Compile Include="Query\DateTimeOffsetPropertyValue.cs" />
     <Compile Include="Query\Extensions\FilterByAccessExtensions.cs" />
     <Compile Include="Query\FilterComposite.cs" />
+    <Compile Include="Query\NotFilter.cs" />
     <Compile Include="Query\GroupingExpression.cs" />
     <Compile Include="Query\IFilter.cs" />
     <Compile Include="Query\ISearchPropertyValue.cs" />

--- a/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
+++ b/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
@@ -7,8 +7,12 @@ namespace Forte.EpiServer.AzureSearch.Model
     {
         [IsSearchable]
         public string[] ContentBody { get; set; }
-		
+
         public int ContentId { get; set; }
+
+        [IsFilterable]
+        public string ContentIdString => ContentId.ToString();
+
         public string ContentComplexReference { get; set; }
         public string ContentImageUrl { get; set; }
         public int ContentImageReferenceId { get; set; }

--- a/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
+++ b/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
@@ -11,8 +11,6 @@ namespace Forte.EpiServer.AzureSearch.Model
         public int ContentId { get; set; }
 
         [IsFilterable]
-        public string ContentIdString => ContentId.ToString();
-
         public string ContentComplexReference { get; set; }
         public string ContentImageUrl { get; set; }
         public int ContentImageReferenceId { get; set; }

--- a/Forte.EpiServer.AzureSearch/Plugin/ContentIndexer.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/ContentIndexer.cs
@@ -50,7 +50,7 @@ namespace Forte.EpiServer.AzureSearch.Plugin
             }
             catch (Exception e)
             {
-                indexContentRequest.Statistics.FailedIds.Add(rootContentLink);
+                indexContentRequest.Statistics.FailedContentReferences.Add(rootContentLink);
                 indexContentRequest.Statistics.Exceptions.Add(e);
             }
             

--- a/Forte.EpiServer.AzureSearch/Plugin/ContentIndexingScheduledJob.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/ContentIndexingScheduledJob.cs
@@ -61,7 +61,7 @@ namespace Forte.EpiServer.AzureSearch.Plugin
             {
                 message += "Exceptions threshold reached. " +
                            $"Exceptions: {string.Join(NewLine + NewLine, indexContentRequest.Statistics.Exceptions.Select(e => e.ToString()))}{NewLine}{NewLine}" +
-                           $"Failed for ids: {string.Join(",", indexContentRequest.Statistics.FailedIds.Select(c => c.ID))}";
+                           $"Failed for content references: {string.Join(",", indexContentRequest.Statistics.FailedContentReferences.Select(c => c.ToString()))}";
 
                 throw new ScheduledJobFailedException(message);
             }
@@ -70,8 +70,7 @@ namespace Forte.EpiServer.AzureSearch.Plugin
             {
                 OnStatusChanged("Clearing outdated items...");
 
-                var contentIdsThatCanStayOutdated = indexContentRequest.Statistics.FailedIds.Select(c => c.ID).ToList();
-                _indexGarbageCollector.RemoveOutdatedContent(jobStartTime, contentIdsThatCanStayOutdated).GetAwaiter().GetResult();
+                _indexGarbageCollector.RemoveOutdatedContent(jobStartTime, indexContentRequest.Statistics.FailedContentReferences).GetAwaiter().GetResult();
             }
 
             stopWatch.Stop();

--- a/Forte.EpiServer.AzureSearch/Plugin/ContentIndexingScheduledJob.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/ContentIndexingScheduledJob.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using EPiServer.Core;
 using EPiServer.PlugIn;
@@ -60,8 +59,8 @@ namespace Forte.EpiServer.AzureSearch.Plugin
             if (exceptionsThresholdReached)
             {
                 message += "Exceptions threshold reached. " +
-                           $"Exceptions: {string.Join(NewLine + NewLine, indexContentRequest.Statistics.Exceptions.Select(e => e.ToString()))}{NewLine}{NewLine}" +
-                           $"Failed for content references: {string.Join(",", indexContentRequest.Statistics.FailedContentReferences.Select(c => c.ToString()))}";
+                           $"Exceptions: {string.Join(NewLine + NewLine, indexContentRequest.Statistics.Exceptions)}{NewLine}{NewLine}" +
+                           $"Failed for content references: {string.Join(",", indexContentRequest.Statistics.FailedContentReferences)}";
 
                 throw new ScheduledJobFailedException(message);
             }

--- a/Forte.EpiServer.AzureSearch/Plugin/IIndexGarbageCollector.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/IIndexGarbageCollector.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using EPiServer.Core;
 
 namespace Forte.EpiServer.AzureSearch.Plugin
 {
     public interface IIndexGarbageCollector
     {
-        Task RemoveOutdatedContent(DateTimeOffset olderThan, IList<int> contentIdsToPreserve);
+        Task RemoveOutdatedContent(DateTimeOffset olderThan, IList<ContentReference> contentReferencesToPreserve);
     }
 }

--- a/Forte.EpiServer.AzureSearch/Plugin/IIndexGarbageCollector.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/IIndexGarbageCollector.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Forte.EpiServer.AzureSearch.Plugin
 {
     public interface IIndexGarbageCollector
     {
-        Task RemoveOutdatedContent(DateTimeOffset olderThan);
+        Task RemoveOutdatedContent(DateTimeOffset olderThan, IList<int> contentIdsToPreserve);
     }
 }

--- a/Forte.EpiServer.AzureSearch/Plugin/IndexGarbageCollector.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/IndexGarbageCollector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EPiServer.Core;
 using Forte.EpiServer.AzureSearch.Model;
 using Forte.EpiServer.AzureSearch.Query;
 
@@ -16,19 +17,19 @@ namespace Forte.EpiServer.AzureSearch.Plugin
             _azureSearchService = azureSearchService;
         }
 
-        public async Task RemoveOutdatedContent(DateTimeOffset olderThan, IList<int> contentIdsToPreserve)
+        public async Task RemoveOutdatedContent(DateTimeOffset olderThan, IList<ContentReference> contentReferencesToPreserve)
         {
-            const int maxContentIdsToPreserve = 1000;
-            if (contentIdsToPreserve.Count > maxContentIdsToPreserve)
+            const int maxContentReferencesToPreserve = 1000;
+            if (contentReferencesToPreserve.Count > maxContentReferencesToPreserve)
             {
-                throw new ArgumentException($"Number of content IDs to preserve cannot be greater than {maxContentIdsToPreserve}", nameof(contentIdsToPreserve));
+                throw new ArgumentException($"Number of content references to preserve cannot be greater than {maxContentReferencesToPreserve}", nameof(contentReferencesToPreserve));
             }
 
             const int topResults = 1000;
 
             var query = new AzureSearchQueryBuilder()
                 .Top(topResults)
-                .Filter(new NotFilter(new AzureSearchFilterSearchIn(nameof(ContentDocument.ContentIdString), contentIdsToPreserve.Select(id => id.ToString()))))
+                .Filter(new NotFilter(new AzureSearchFilterSearchIn(nameof(ContentDocument.ContentComplexReference), contentReferencesToPreserve.Select(reference => reference.ToString()))))
                 .Filter(AzureSearchQueryFilter.LessThan(nameof(ContentDocument.IndexedAt), new DateTimeOffsetPropertyValue(olderThan)))
                 .Build();
 

--- a/Forte.EpiServer.AzureSearch/Plugin/IndexGarbageCollector.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/IndexGarbageCollector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Forte.EpiServer.AzureSearch.Model;
@@ -15,11 +16,19 @@ namespace Forte.EpiServer.AzureSearch.Plugin
             _azureSearchService = azureSearchService;
         }
 
-        public async Task RemoveOutdatedContent(DateTimeOffset olderThan)
+        public async Task RemoveOutdatedContent(DateTimeOffset olderThan, IList<int> contentIdsToPreserve)
         {
+            const int maxContentIdsToPreserve = 1000;
+            if (contentIdsToPreserve.Count > maxContentIdsToPreserve)
+            {
+                throw new ArgumentException($"Number of content IDs to preserve cannot be greater than {maxContentIdsToPreserve}", nameof(contentIdsToPreserve));
+            }
+
             const int topResults = 1000;
+
             var query = new AzureSearchQueryBuilder()
                 .Top(topResults)
+                .Filter(new NotFilter(new AzureSearchFilterSearchIn(nameof(ContentDocument.ContentIdString), contentIdsToPreserve.Select(id => id.ToString()))))
                 .Filter(AzureSearchQueryFilter.LessThan(nameof(ContentDocument.IndexedAt), new DateTimeOffsetPropertyValue(olderThan)))
                 .Build();
 

--- a/Forte.EpiServer.AzureSearch/Plugin/IndexStatistics.cs
+++ b/Forte.EpiServer.AzureSearch/Plugin/IndexStatistics.cs
@@ -6,7 +6,7 @@ namespace Forte.EpiServer.AzureSearch.Plugin
 {
     public class IndexStatistics
     {
-        public IList<ContentReference> FailedIds { get; } = new List<ContentReference>();
+        public IList<ContentReference> FailedContentReferences { get; } = new List<ContentReference>();
         public IList<Exception> Exceptions { get; } = new List<Exception>();
     }
 }

--- a/Forte.EpiServer.AzureSearch/Query/AzureSearchFilterSearchIn.cs
+++ b/Forte.EpiServer.AzureSearch/Query/AzureSearchFilterSearchIn.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Forte.EpiServer.AzureSearch.Query
+{
+    public class AzureSearchFilterSearchIn : IFilter
+    {
+        public AzureSearchFilterSearchIn(string propertyName, IEnumerable<string> possibleValues, string separator = " ")
+        {
+            PropertyName = propertyName;
+            PossibleValues = possibleValues;
+            Separator = separator;
+        }
+
+        public string PropertyName { get; }
+
+        public IEnumerable<string> PossibleValues { get; }
+
+        public string Separator { get; }
+
+        public string ToQueryString()
+        {
+            return $"search.in({PropertyName}, '{string.Join(Separator, PossibleValues)}', '{Separator}')";
+        }
+    }
+}

--- a/Forte.EpiServer.AzureSearch/Query/NotFilter.cs
+++ b/Forte.EpiServer.AzureSearch/Query/NotFilter.cs
@@ -1,0 +1,14 @@
+﻿namespace Forte.EpiServer.AzureSearch.Query
+{
+    public class NotFilter : IFilter
+    {
+        private readonly IFilter _filter;
+
+        public NotFilter(IFilter filter)
+        {
+            _filter = filter;
+        }
+
+        public string ToQueryString() => $"not {_filter.ToQueryString()}";
+    }
+}


### PR DESCRIPTION
When exceptions threshold is reached job throws exception to preserve old index and mark current run as failed