### PR TITLE
Add Sorting functionality

### DIFF
--- a/Forte.EpiServer.AzureSearch/AzureSearchService.cs
+++ b/Forte.EpiServer.AzureSearch/AzureSearchService.cs
@@ -68,6 +68,7 @@ namespace Forte.EpiServer.AzureSearch
                 Filter = query.Filter,
                 IncludeTotalResultCount = true,
                 ScoringProfile = query.ScoringProfile,
+                OrderBy = query.OrderBy,
             };
         }
         

--- a/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
+++ b/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
@@ -36,9 +36,6 @@ namespace Forte.EpiServer.AzureSearch.Model
         [IsSortable]
         public DateTimeOffset CreatedAt { get; set; }
         
-        [IsSortable]
-        public int SortIndex { get; set; }
-        
         [IsFilterable]
         public DateTimeOffset? StopPublishUtc { get; set; }
         
@@ -47,5 +44,10 @@ namespace Forte.EpiServer.AzureSearch.Model
         
         [IsFilterable]
         public string[] AccessUsers { get; set; }
+
+        public class SortableFields
+        {
+            public const string CreatedAt = nameof(ContentDocument.CreatedAt);
+        }
     }
 }

--- a/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
+++ b/Forte.EpiServer.AzureSearch/Model/ContentDocument.cs
@@ -32,6 +32,12 @@ namespace Forte.EpiServer.AzureSearch.Model
         public string ContentTypeName { get; set; }
                 
         public string ContentUrl { get; set; }
+
+        [IsSortable]
+        public DateTimeOffset CreatedAt { get; set; }
+        
+        [IsSortable]
+        public int SortIndex { get; set; }
         
         [IsFilterable]
         public DateTimeOffset? StopPublishUtc { get; set; }

--- a/Forte.EpiServer.AzureSearch/Model/DefaultDocumentBuilder.cs
+++ b/Forte.EpiServer.AzureSearch/Model/DefaultDocumentBuilder.cs
@@ -68,6 +68,8 @@ namespace Forte.EpiServer.AzureSearch.Model
             {
                 document.ContentTypeName = pageData.PageTypeName;
                 document.StopPublishUtc = pageData.StopPublish.HasValue ? new DateTimeOffset(pageData.StopPublish.Value) : (DateTimeOffset?) null;
+                document.CreatedAt = pageData.Created;
+                document.SortIndex = pageData.SortIndex;
 
                 document.AccessRoles = GetReadAccessEntriesNames(pageData, SecurityEntityType.Role);
                 document.AccessUsers = GetReadAccessEntriesNames(pageData, SecurityEntityType.User);

--- a/Forte.EpiServer.AzureSearch/Model/DefaultDocumentBuilder.cs
+++ b/Forte.EpiServer.AzureSearch/Model/DefaultDocumentBuilder.cs
@@ -69,7 +69,6 @@ namespace Forte.EpiServer.AzureSearch.Model
                 document.ContentTypeName = pageData.PageTypeName;
                 document.StopPublishUtc = pageData.StopPublish.HasValue ? new DateTimeOffset(pageData.StopPublish.Value) : (DateTimeOffset?) null;
                 document.CreatedAt = pageData.Created;
-                document.SortIndex = pageData.SortIndex;
 
                 document.AccessRoles = GetReadAccessEntriesNames(pageData, SecurityEntityType.Role);
                 document.AccessUsers = GetReadAccessEntriesNames(pageData, SecurityEntityType.User);

--- a/Forte.EpiServer.AzureSearch/Query/AzureSearchQuery.cs
+++ b/Forte.EpiServer.AzureSearch/Query/AzureSearchQuery.cs
@@ -28,7 +28,8 @@ namespace Forte.EpiServer.AzureSearch.Query
         public string HighlightPostTag { get; set; }
         public int Skip { get; set; }
         public string ScoringProfile { get; set; }
-        
+        public IList<string> OrderBy { get; set; }
+
         public object Clone()
         {
             var serializedObject = JsonConvert.SerializeObject(this);

--- a/Forte.EpiServer.AzureSearch/Query/AzureSearchQueryBuilder.cs
+++ b/Forte.EpiServer.AzureSearch/Query/AzureSearchQueryBuilder.cs
@@ -97,6 +97,13 @@ namespace Forte.EpiServer.AzureSearch.Query
             
             return this;
         }
+
+        public AzureSearchQueryBuilder OrderBy(IList<string> orderBy)
+        {
+            _query.OrderBy = orderBy;
+
+            return this;
+        }
         
         private sealed class HighlightField
         {


### PR DESCRIPTION
There is this common scenario: I want to get 10 latest articles that match the given search criteria.

In order to do so in the current state of a code I need:
- search for all items that match criteria in AzureSearch
- load all items from IContentLoader in EpiServer
- sort them by CreatedAt 
- take 10

This is not optimal as I need to load all items from the content repository just to take 10 of them in the end

In this PR : 
- SortBy is added so you can add this property to AzureSearchQuery
- SortIndex and CreatedAt properties are added to ContentDocument 